### PR TITLE
Fix unit tests for Chef 12.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,8 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
-    - bundle update
-    - rvm-exec 2.0.0-p645 bundle update
+    - bundle install --without=development integration
+    - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:
     - /home/ubuntu/.rvm/gems
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
+    - gem install -V berkshelf
+    - rvm-exec 2.0.0-p645 gem install -V berkshelf
     - bundle install --without=development integration
     - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:

--- a/spec/libraries/provider_gimp_app_debian_spec.rb
+++ b/spec/libraries/provider_gimp_app_debian_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_debian'
 
 describe Chef::Provider::GimpApp::Debian do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_gimp_app_freebsd_spec.rb
+++ b/spec/libraries/provider_gimp_app_freebsd_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_freebsd'
 
 describe Chef::Provider::GimpApp::Freebsd do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_gimp_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_gimp_app_mac_os_x_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_mac_os_x'
 
 describe Chef::Provider::GimpApp::MacOsX do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the app directory' do

--- a/spec/libraries/provider_gimp_app_package_spec.rb
+++ b/spec/libraries/provider_gimp_app_package_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_package'
 
 describe Chef::Provider::GimpApp::Package do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#install!' do
     context 'default resource attributes' do

--- a/spec/libraries/provider_gimp_app_rhel_spec.rb
+++ b/spec/libraries/provider_gimp_app_rhel_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_rhel'
 
 describe Chef::Provider::GimpApp::Rhel do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_gimp_app_spec.rb
+++ b/spec/libraries/provider_gimp_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app'
 
 describe Chef::Provider::GimpApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do

--- a/spec/libraries/provider_gimp_app_suse_spec.rb
+++ b/spec/libraries/provider_gimp_app_suse_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_suse'
 
 describe Chef::Provider::GimpApp::Suse do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_gimp_app_windows_spec.rb
+++ b/spec/libraries/provider_gimp_app_windows_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_gimp_app_windows'
 
 describe Chef::Provider::GimpApp::Windows do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::GimpApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::GimpApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the app directory' do
@@ -117,8 +118,9 @@ describe Chef::Provider::GimpApp::Windows do
     end
 
     it 'returns a path in the Chef cache dir' do
+      res = provider.send(:download_path)
       expected = "#{Chef::Config[:file_cache_path]}/gimp-2.8.14-setup.exe"
-      expect(provider.send(:download_path)).to eq(expected)
+      expect(res).to eq(expected)
     end
   end
 


### PR DESCRIPTION
`Chef::Provider.initialize` now raises an exception if passed nil as a `run_context`.
